### PR TITLE
bumping to newer activemq-bin

### DIFF
--- a/net-misc/activemq-bin/activemq-bin-5.15.6.ebuild
+++ b/net-misc/activemq-bin/activemq-bin-5.15.6.ebuild
@@ -1,0 +1,48 @@
+EAPI="5"
+
+inherit eutils user systemd
+
+DESCRIPTION="Apache ActiveMQ is the most popular and powerful open source messaging and Integration Patterns server"
+HOMEPAGE="http://activemq.apache.org/"
+LICENSE="Apache-2.0"
+SRC_URI="mirror://apache/activemq/${PV}/apache-activemq-${PV}-bin.tar.gz"
+RESTRICT="mirror"
+SLOT="0"
+KEYWORDS="x86 amd64"
+IUSE="-opencast"
+
+RDEPEND=">=virtual/jdk-1.6"
+
+S="${WORKDIR}/apache-activemq-${PV}"
+MY_PN="activemq"
+INSTALL_DIR="/opt/${MY_PN}"
+
+pkg_setup() {
+	enewuser ${MY_PN} -1 /bin/bash ${INSTALL_DIR}
+}
+
+src_prepare() {
+	use opencast && epatch "${FILESDIR}/opencast5.activemq.xml.patch"
+
+	cd "${S}"
+	find . \( -name \*.bat -or -name \*.exe \) -delete
+}
+
+src_install() {
+	insinto ${INSTALL_DIR}
+
+	doins -r *
+
+	fperms 755 "${INSTALL_DIR}/bin/${MY_PN}"
+	make_wrapper "${MY_PN}" "${INSTALL_DIR}/bin/${MY_PN}"
+
+	fperms 755 "${INSTALL_DIR}/bin/${MY_PN}"
+	make_wrapper "${MY_PN}" "${INSTALL_DIR}/bin/${MY_PN}"
+
+	systemd_dounit "${FILESDIR}/activemq.service"
+
+	fowners -R ${MY_PN}:${MY_PN} ${INSTALL_DIR}
+
+	echo "CONFIG_PROTECT=\"${INSTALL_DIR}/conf\"" > "${T}/25${MY_PN}" || die
+	doenvd "${T}/25${MY_PN}"
+}


### PR DESCRIPTION
Changes and fixes:

# 5.15.3 -> 5.15.4
## Bug

- [AMQ-6901] - Destination with wildcard may not have correct policy applied if multiple wildcard policies exist
- [AMQ-6924] - StoreDurableSubscriberCursor does not timeout properly on non-persistent message send
- [AMQ-6940] - Significant memory footprint increase from 5.8.0 to 5.15.3

## Improvement

- [AMQ-6934] - Update Jackson to latest version
- [AMQ-6935] - Update Jolokia to 1.5.0
- [AMQ-6958] - AMQP: Set a default maxFrameSize for AMQP connections
- [AMQ-6959] - Avoid creating a Throwable in case of non-trace logging
- [AMQ-6962] - Update Spring framework version

## Wish

- [AMQ-6930] - bin/activemq should allow stdout/stderr to some file instead of /dev/null for daemon mode

## Task

- [AMQ-6909] - AMQP: Update Qpid JMS to latest 0.32.0 release and Proton-j to 0.27.1 to match

# 5.15.4 -> 5.15.5
## Bug

- [AMQ-6967] - Periodic expiry with no consumers fails to page in messages if cache has flipped
- [AMQ-6968] - Incorrect error can be thrown from method that receives a security exception
- [AMQ-6970] - SSL config-params are not propagated inside rar correctly
- [AMQ-6990] - ActiveMQ 5.15.4 _commons-beanutils-core-1.8.0.jar_ which has one **high severity CVE** against it.
- [AMQ-6992] - ActiveMQ 5.15.4 _jackson-databind-2.9.4.jar_ which has one **high severity CVE** against it.
- [AMQ-6994] - ActiveMQ 5.15.4 _tomcat-servlet-api-8.0.24.jar_ which has four **high severity CVEs** against it.
- [AMQ-6996] - ActiveMQ 5.15.4 _xercesImpl-2.11.0.jar_ which has one **high severity CVE** against it.
- [AMQ-7001] - Contention on message properties with amqp jms transfromer and kahadb concurrentStoreAndDispatch
- [AMQ-7002] - Activemq SchedulerBroker doSchedule can schedule duplicate jobIds leading to runtime exception
- [AMQ-7006] - STOMP protocol converter tracks pending ACKS in Client mode but doesn't remove all ACK'd IDs, just the one submitted.
- [AMQ-7011] - Activemq 5.15.4 Stomp protocol allowed to enter deadlock via dispatch sync
- [AMQ-7012] - Misleading error in org.apache.activemq.transport.stomp.ProtocolConverter
- [AMQ-7013] - XATransactionID hash function may generate duplicates.
- [AMQ-7017] - ProducerBrokerExchange.getPercentageBlocked() throws ArithmeticException (divide by zero)
- [AMQ-7019] - ActiveMQ 5.15.4 _jolokia.jar_ which has one **high severity CVE** against it.


## New Feature

- [AMQ-7015] - Startup performance improvement when log contains prepared transactions.
- [AMQ-7023] - Add OWASP Dependency Check to build (all open source projects everywhere)


## Improvement

- [AMQ-6974] - overflow errors with timestamps
- [AMQ-7004] - Request for improved FailoverTransport logging
- [AMQ-7021] - DestinationMap access inside Abstract Region readwrite lock does not need sync
- [AMQ-7027] - Upgrade Jetty to 9.2.25.v20180606
- [AMQ-7029] - Dependency Updates


## Task

- [AMQ-6997] - AMQP: Update Qpid JMS and Proton-J latest versions
- [AMQ-7026] - Update Derby version to 10.14.2.0
- [AMQ-7032] - Update Shiro to version 1.2.6


# 5.15.5 -> 5.15.6
This release **enables** ActiveMQ client TLS hostname validation **by default** which can cause a _client connection failure_ for server certificates that do not match the server hostname. Please refer to SSL Transport Reference for configuration and AMQ-7047 - for more information.

## Bug

- [AMQ-6954] - Queue page on web console displays URL parameter without proper encoding

## Improvement

- [AMQ-7036] - FailoverTransport should not report errors trying to connect to Slave Broker
- [AMQ-7038] - AMQP: Update Qpid JMS Proton-J and Netty latest versions
- [AMQ-7047] - Add support for TLS hostname verification